### PR TITLE
chore: make docker rebuilding faster

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.10
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY . /app
+COPY requirements.txt requirements.txt
 RUN pip install -r ./requirements.txt
+COPY . .


### PR DESCRIPTION
# Why

With that setup, the docker doesn't have to run `pip install -r ./requirements.txt` if only the source code was changed. 