### PR TITLE
chore: clean up indexers

### DIFF
--- a/backend/fregepoc/indexers/admin.py
+++ b/backend/fregepoc/indexers/admin.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from django.contrib import admin
 
 from fregepoc.indexers.base import indexers
@@ -7,7 +9,5 @@ from fregepoc.utils.admin import AutoModelAdmin
 # https://medium.com/hackernoon/automatically-register-all-models-in-django-admin-django-tips-481382cf75e5
 
 for indexer_model in indexers:
-    try:
+    with contextlib.suppress(admin.sites.AlreadyRegistered):
         admin.site.register(indexer_model, AutoModelAdmin)
-    except admin.sites.AlreadyRegistered:
-        pass

--- a/backend/fregepoc/indexers/admin.py
+++ b/backend/fregepoc/indexers/admin.py
@@ -1,13 +1,13 @@
 from django.contrib import admin
 
-from fregepoc.indexers.models import GitHubIndexer
+from fregepoc.indexers.base import indexers
+from fregepoc.utils.admin import AutoModelAdmin
 
+# Adapted from:
+# https://medium.com/hackernoon/automatically-register-all-models-in-django-admin-django-tips-481382cf75e5
 
-@admin.register(GitHubIndexer)
-class GitHubIndexerAdmin(admin.ModelAdmin):
-    list_display = (
-        "min_forks",
-        "min_stars",
-        "current_page",
-        "rate_limit_timeout",
-    )
+for indexer_model in indexers:
+    try:
+        admin.site.register(indexer_model, AutoModelAdmin)
+    except admin.sites.AlreadyRegistered:
+        pass

--- a/backend/fregepoc/indexers/base.py
+++ b/backend/fregepoc/indexers/base.py
@@ -1,13 +1,32 @@
 import abc
+from collections.abc import Iterator
+from datetime import timedelta
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from fregepoc.repositories.models import Repository
+from fregepoc.utils.models import SingletonModel
 
 indexers = []
 
 
-class BaseIndexer:
+class BaseIndexer(SingletonModel):
+    rate_limit_timeout = models.DurationField(
+        _("rate limit timeout"),
+        default=timedelta(minutes=30),
+    )
+
+    #: A variable signifying whether the indexer has been throttled.
+    rate_limit_exceeded: bool = False
+
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
         indexers.append(cls)
 
     @abc.abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Repository]:
         ...
+
+    class Meta:
+        abstract = True

--- a/backend/fregepoc/indexers/migrations/0001_initial.py
+++ b/backend/fregepoc/indexers/migrations/0001_initial.py
@@ -58,6 +58,6 @@ class Migration(migrations.Migration):
             options={
                 "abstract": False,
             },
-            bases=(models.Model, fregepoc.indexers.base.BaseIndexer),
+            bases=(fregepoc.indexers.base.BaseIndexer,),
         ),
     ]

--- a/backend/fregepoc/indexers/models.py
+++ b/backend/fregepoc/indexers/models.py
@@ -1,5 +1,4 @@
 import os
-from datetime import timedelta
 
 import github.GithubException
 from django.db import models
@@ -8,10 +7,9 @@ from github import Github
 
 from fregepoc.indexers.base import BaseIndexer
 from fregepoc.repositories.models import Repository
-from fregepoc.utils.models import SingletonModel
 
 
-class GitHubIndexer(SingletonModel, BaseIndexer):
+class GitHubIndexer(BaseIndexer):
     min_forks = models.PositiveIntegerField(
         _("min forks"),
         default=100,
@@ -25,14 +23,6 @@ class GitHubIndexer(SingletonModel, BaseIndexer):
         default=0,
         help_text=_("The last visited page via GitHub API."),
     )
-    rate_limit_timeout = models.DurationField(
-        _("rate limit timeout"),
-        default=timedelta(minutes=30),
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.rate_limit_exceeded = False
 
     def __iter__(self):
         github_token = os.environ.get("GITHUB_TOKEN")
@@ -66,3 +56,7 @@ class GitHubIndexer(SingletonModel, BaseIndexer):
                 self.rate_limit_exceeded = True
                 break
             yield from repos_to_process
+
+    class Meta:
+        verbose_name = _("Github Indexer")
+        verbose_name_plural = verbose_name

--- a/backend/fregepoc/repositories/tasks.py
+++ b/backend/fregepoc/repositories/tasks.py
@@ -8,7 +8,7 @@ from django.apps import apps
 from django.db import transaction
 from django.utils import timezone
 
-from fregepoc.indexers.base import indexers
+from fregepoc.indexers.base import BaseIndexer, indexers
 from fregepoc.repositories.analyzers.base import AnalyzerFactory
 from fregepoc.repositories.models import Repository, RepositoryFile
 from fregepoc.repositories.utils.paths import (
@@ -22,7 +22,7 @@ logger = get_task_logger(__name__)
 def _finalize_repo_analysis(repo_obj):
     if not repo_obj.files.filter(analyzed=False).exists():
         repo_obj.analyzed = True
-        repo_obj.save()
+        repo_obj.save(update_fields=["analyzed"])
         logger.info(
             f"Repository {repo_obj.git_url} fully analyzed, "
             "deleting files from disk..."
@@ -40,12 +40,10 @@ def init_worker(**kwargs):
 @shared_task
 def crawl_repos_task(indexer_class_name):
     indexer_model = apps.get_model("indexers", indexer_class_name)
-    indexer = indexer_model.load()
+    indexer: BaseIndexer = indexer_model.load()
     for repo in indexer:
-        # TODO: Use a better repo identifier to perform a check.
-        if not Repository.objects.filter(
-            name=repo.name, analyzed=True
-        ).exists():
+        repo.refresh_from_db()
+        if not repo.analyzed:
             process_repo_task.apply_async(args=(repo.pk,))
 
     if indexer.rate_limit_exceeded:
@@ -76,7 +74,7 @@ def process_repo_task(repo_pk):
     try:
         repo_obj = git.Repo.clone_from(repo.git_url, repo_local_path)
         repo.fetch_time = timezone.now()
-        repo.save()
+        repo.save(update_fields=["fetch_time"])
         logger.info("Repository cloned")
     except git.exc.GitCommandError:
         try:

--- a/backend/fregepoc/utils/admin.py
+++ b/backend/fregepoc/utils/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+
+
+class AutoModelAdmin(admin.ModelAdmin):
+    def __init__(self, model, admin_site):
+        self.list_display = [field.name for field in model._meta.fields]
+        super().__init__(model, admin_site)


### PR DESCRIPTION
## Why
There is an inconsistency in the `BaseIndexer` interface detected in the crawl_repo_task. The before mentioned task presume that all the indexers possess the attributes `rate_limit_timeout` and `rate_limit_exceeded`, which in general might not be guaranteed. 
Goal: Unify `BaseIndexer` interface
## How
- Move all the necessary attributes and functions to the `BaseIndexer` class
- Get rid of `SingletonModel` in the final indexer classes inheritance list.
- Provide a way to automatically register indexers in Django Admin.

## Test plan
- Provide unit tests for indexers and admin models