### PR TITLE
fix: apply linter fixes

### DIFF
--- a/backend/fregepoc/repositories/migrations/0002_alter_repository_description_and_more.py
+++ b/backend/fregepoc/repositories/migrations/0002_alter_repository_description_and_more.py
@@ -6,19 +6,30 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('repositories', '0001_initial'),
+        ("repositories", "0001_initial"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='repository',
-            name='description',
-            field=models.TextField(blank=True, default='', help_text='The description of the repository', max_length=2048, verbose_name='Repository description'),
+            model_name="repository",
+            name="description",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="The description of the repository",
+                max_length=2048,
+                verbose_name="Repository description",
+            ),
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='repositoryfile',
-            name='repo_relative_file_path',
-            field=models.CharField(blank=True, help_text='File path, relative to the repository root.', max_length=512, null=True),
+            model_name="repositoryfile",
+            name="repo_relative_file_path",
+            field=models.CharField(
+                blank=True,
+                help_text="File path, relative to the repository root.",
+                max_length=512,
+                null=True,
+            ),
         ),
     ]


### PR DESCRIPTION
`pre-commit run --all-files` found the following issues.

**note** - ran with Python 3.8.10, as 3.10 is not available through apt on Ubuntu 20.04 (see #16).