### PR TITLE
feat: add production environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,3 +27,6 @@ GF_SECURITY_ADMIN_USER=admin
 GF_SECURITY_ADMIN_PASSWORD=passw0rd
 
 GITHUB_TOKEN=
+
+LETSENCRYPT_EMAIL=example@example.com
+BACKEND_HOSTNAME=backend.frege.ii.uj.edu.pl

--- a/.env.template
+++ b/.env.template
@@ -29,4 +29,5 @@ GF_SECURITY_ADMIN_PASSWORD=passw0rd
 GITHUB_TOKEN=
 
 LETSENCRYPT_EMAIL=example@example.com
-BACKEND_HOSTNAME=backend.frege.ii.uj.edu.pl
+BACKEND_HOSTNAME=.localhost
+FRONTEND_URL=http://localhost:4200

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -16,8 +16,8 @@ jobs:
       - name: Set env variables
         run: cp .env.template .env
       - name: Build
-        run: docker compose --profile application build
+        run: docker compose --profile dev build
       - name: Run
-        run: docker compose --profile application up -d
+        run: docker compose --profile dev up -d
       - name: Run tests
         run: docker compose exec -T fregepoc-backend pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run
         run: docker compose --profile dev up -d
       - name: Run tests
-        run: docker compose exec -T fregepoc-backend pytest
+        run: docker compose exec -T fregepoc-backend-dev pytest

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pre-commit run --all-files
 ### Testing
 To run tests from the docker container, execute the following command:
 ```bash
-docker compose exec -T fregepoc-backend pytest
+docker compose exec -T fregepoc-backend-dev pytest
 ```
 
 ### Commit messages convention

--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ and then editing the `.env` file optionally (although the unchanged configuratio
 If the containers were not built yet, you can do so by running the following command:
 
 ```bash
-docker compose --profile application-dev build
+docker compose --profile dev build
 ```
 
 To run the application, you need to use the following command:
 
 ```bash
-docker compose --profile application-dev up
+docker compose --profile dev up
 ```
 
 For the production environment, use the following instead:
 
 ```bash
-docker compose --profile application-prod up -d
+docker compose --profile prod up -d
 ```
 
 >On older versions of Docker, you may need to substitute `docker compose` with `docker-compose`.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,22 @@ and then editing the `.env` file optionally (although the unchanged configuratio
 
 >The following commands should be run from the **root** of the application
 
-To run the application, you need to use the following command:
-
-```bash
-docker compose --profile application up
-```
-
 If the containers were not built yet, you can do so by running the following command:
 
 ```bash
-docker compose --profile application build
+docker compose --profile application-dev build
+```
+
+To run the application, you need to use the following command:
+
+```bash
+docker compose --profile application-dev up
+```
+
+For the production environment, use the following instead:
+
+```bash
+docker compose --profile application-prod up -d
 ```
 
 >On older versions of Docker, you may need to substitute `docker compose` with `docker-compose`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,5 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r ./requirements.txt
+RUN pip install gunicorn==20.1.0
 COPY . .

--- a/backend/fregepoc/settings.py
+++ b/backend/fregepoc/settings.py
@@ -24,6 +24,8 @@ SECRET_KEY = (
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
 ALLOWED_HOSTS = [".localhost", "127.0.0.1"]
+if os.environ.get("BACKEND_HOSTNAME") is not None:
+    ALLOWED_HOSTS.append(os.environ.get("BACKEND_HOSTNAME"))
 
 DJANGO_CORS_ALLOWED_HOSTS = ["http://localhost:4200"]
 
@@ -125,6 +127,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "static"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/backend/fregepoc/settings.py
+++ b/backend/fregepoc/settings.py
@@ -23,11 +23,11 @@ SECRET_KEY = (
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
-ALLOWED_HOSTS = [".localhost", "127.0.0.1"]
-if os.environ.get("BACKEND_HOSTNAME") is not None:
-    ALLOWED_HOSTS.append(os.environ.get("BACKEND_HOSTNAME"))
+ALLOWED_HOSTS = [os.environ.get("BACKEND_HOSTNAME", ".localhost")]
 
-DJANGO_CORS_ALLOWED_HOSTS = ["http://localhost:4200"]
+DJANGO_CORS_ALLOWED_HOSTS = [
+    os.environ.get("FRONTEND_URL", "http://localhost:4200")
+]
 
 # Application definition
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     networks:
       - fregepoc-main
     ports:
-      - "16379:${DOCKER_REDIS_PORT}"
-    profiles: [ "services", "application-dev", "application-prod" ]
+      - "${DOCKER_REDIS_PORT}:16379"
+    profiles: [ "dev", "prod" ]
     restart: on-failure
 
   fregepoc-postgres:
@@ -23,8 +23,8 @@ services:
     networks:
       - fregepoc-main
     ports:
-      - "15432:${DOCKER_POSTGRES_PORT}"
-    profiles: [ "services", "application-dev", "application-prod" ]
+      - "${DOCKER_POSTGRES_PORT}:15432"
+    profiles: [ "dev", "prod" ]
     restart: on-failure
     volumes:
       - fregepoc_postgresql_data:/var/lib/postgresql/data
@@ -49,7 +49,7 @@ services:
       - fregepoc_tmp:${DJANGO_DOWNLOAD_PATH}
     networks:
       - fregepoc-main
-    profiles: [ "application-dev" ]
+    profiles: [ "dev" ]
     restart: on-failure
     env_file:
       - .env
@@ -82,7 +82,7 @@ services:
       - fregepoc-main
     env_file:
       - .env
-    profiles: [ "application-dev" ]
+    profiles: [ "dev" ]
 
   fregepoc-celery-worker:
     <<: *backend
@@ -114,7 +114,7 @@ services:
     volumes:
       - fregepoc_tmp:${DJANGO_DOWNLOAD_PATH}
       - fregepoc_static_files:/app/static
-    profiles: [ "application-prod" ]
+    profiles: [ "prod" ]
 
   fregepoc-backend-nginx:
     image: nginx:1.21
@@ -137,7 +137,7 @@ services:
     environment:
       - VIRTUAL_HOST=${BACKEND_HOSTNAME}
       - LETSENCRYPT_HOST=${BACKEND_HOSTNAME}
-    profiles: [ "application-prod" ]
+    profiles: [ "prod" ]
 
   fregepoc-grafana-prod:
     <<: *grafana
@@ -146,7 +146,7 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=true
       - GF_USERS_ALLOW_ORG_CREATE=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
-    profiles: [ "application-prod" ]
+    profiles: [ "prod" ]
 
   fregepoc-proxy:
     image: nginxproxy/nginx-proxy:1.0
@@ -164,7 +164,7 @@ services:
       - fregepoc_proxy_vhost:/etc/nginx/vhost.d
       - fregepoc_proxy_html:/usr/share/nginx/html
       - fregepoc_proxy_certs:/etc/nginx/certs:ro
-    profiles: [ "application-prod" ]
+    profiles: [ "prod" ]
 
   fregepoc-proxy-acme:
     image: nginxproxy/acme-companion:2.2
@@ -182,7 +182,7 @@ services:
     environment:
       - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
       - NGINX_PROXY_CONTAINER=fregepoc-proxy
-    profiles: [ "application-prod" ]
+    profiles: [ "prod" ]
 
 networks:
   fregepoc-main:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,32 +4,32 @@ services:
   fregepoc-redis:
     container_name: fregepoc-redis
     hostname: fregepoc-redis
-    image: redis:latest
+    image: redis:7.0
     networks:
       - fregepoc-main
     ports:
       - "16379:${DOCKER_REDIS_PORT}"
-    profiles: ["services", "application"]
+    profiles: [ "services", "application-dev", "application-prod" ]
     restart: on-failure
 
   fregepoc-postgres:
     container_name: fregepoc-postgres
     hostname: fregepoc-postgres
-    image: postgres:latest
+    image: postgres:14.2
     environment:
-       - POSTGRES_USER=${DJANGO_DATABASE_USER}
-       - POSTGRES_PASSWORD=${DJANGO_DATABASE_PASSWORD}
-       - POSTGRES_DB=${DJANGO_DATABASE_NAME}
+      - POSTGRES_USER=${DJANGO_DATABASE_USER}
+      - POSTGRES_PASSWORD=${DJANGO_DATABASE_PASSWORD}
+      - POSTGRES_DB=${DJANGO_DATABASE_NAME}
     networks:
       - fregepoc-main
     ports:
       - "15432:${DOCKER_POSTGRES_PORT}"
-    profiles: ["services", "application"]
+    profiles: [ "services", "application-dev", "application-prod" ]
     restart: on-failure
     volumes:
       - fregepoc_postgresql_data:/var/lib/postgresql/data
 
-  fregepoc-backend: &backend
+  fregepoc-backend-dev: &backend
     container_name: fregepoc-backend
     image: fregepoc-backend-image
     build: ./backend
@@ -49,13 +49,13 @@ services:
       - fregepoc_tmp:${DJANGO_DOWNLOAD_PATH}
     networks:
       - fregepoc-main
-    profiles: [ "application" ]
+    profiles: [ "application-dev" ]
     restart: on-failure
     env_file:
       - .env
 
   fregepoc-prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v2.35.0
     container_name: fregepoc-prometheus
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
@@ -64,8 +64,8 @@ services:
     networks:
       - fregepoc-main
 
-  fregepoc-grafana:
-    image: grafana/grafana
+  fregepoc-grafana-dev: &grafana
+    image: grafana/grafana:8.5.2
     container_name: fregepoc-grafana
     depends_on:
       - fregepoc-prometheus
@@ -82,11 +82,12 @@ services:
       - fregepoc-main
     env_file:
       - .env
+    profiles: [ "application-dev" ]
 
   fregepoc-celery-worker:
     <<: *backend
     container_name: fregepoc-celery-worker
-    ports: []
+    ports: [ ]
     command: >
       sh -c "python3 manage.py celery_dev_autoreload"
 
@@ -103,6 +104,86 @@ services:
       - fregepoc-celery-worker
       - fregepoc-redis
 
+  fregepoc-backend-prod:
+    <<: *backend
+    command: >
+      sh -c "python manage.py migrate --noinput
+      && python manage.py initadmin
+      && python manage.py collectstatic --noinput
+      && gunicorn fregepoc.wsgi:application --bind 0.0.0.0:${DOCKER_BACKEND_PORT}"
+    volumes:
+      - fregepoc_tmp:${DJANGO_DOWNLOAD_PATH}
+      - fregepoc_static_files:/app/static
+    profiles: [ "application-prod" ]
+
+  fregepoc-backend-nginx:
+    image: nginx:1.21
+    container_name: fregepoc-backend-nginx
+    hostname: fregepoc-backend-nginx
+    restart: on-failure
+    volumes:
+      - ./nginx:/etc/nginx/templates
+      - fregepoc_static_files:/var/www/static
+    networks:
+      - fregepoc-main
+    ports:
+      - "8080:80"
+    expose:
+      - 8080
+    depends_on:
+      - fregepoc-backend-prod
+    env_file:
+      - .env
+    environment:
+      - VIRTUAL_HOST=${BACKEND_HOSTNAME}
+      - LETSENCRYPT_HOST=${BACKEND_HOSTNAME}
+    profiles: [ "application-prod" ]
+
+  fregepoc-grafana-prod:
+    <<: *grafana
+    environment:
+      - GF_USERS_DEFAULT_THEME=dark
+      - GF_USERS_ALLOW_SIGN_UP=true
+      - GF_USERS_ALLOW_ORG_CREATE=false
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+    profiles: [ "application-prod" ]
+
+  fregepoc-proxy:
+    image: nginxproxy/nginx-proxy:1.0
+    container_name: fregepoc-proxy
+    hostname: fregepoc-proxy
+    restart: on-failure
+    networks:
+      - fregepoc-main
+    ports:
+      - "${DOCKER_EGRESS_IP}:80:80"
+      - "${DOCKER_EGRESS_IP}:443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - fregepoc_proxy_conf:/etc/nginx/conf.d
+      - fregepoc_proxy_vhost:/etc/nginx/vhost.d
+      - fregepoc_proxy_html:/usr/share/nginx/html
+      - fregepoc_proxy_certs:/etc/nginx/certs:ro
+    profiles: [ "application-prod" ]
+
+  fregepoc-proxy-acme:
+    image: nginxproxy/acme-companion:2.2
+    container_name: fregepoc-proxy-acme
+    hostname: fregepoc-proxy-acme
+    restart: on-failure
+    networks:
+      - fregepoc-main
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - fregepoc_proxy_conf:/etc/nginx/conf.d
+      - fregepoc_proxy_vhost:/etc/nginx/vhost.d
+      - fregepoc_proxy_html:/usr/share/nginx/html
+      - fregepoc_proxy_certs:/etc/nginx/certs:rw
+    environment:
+      - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
+      - NGINX_PROXY_CONTAINER=fregepoc-proxy
+    profiles: [ "application-prod" ]
+
 networks:
   fregepoc-main:
 
@@ -110,3 +191,10 @@ volumes:
   fregepoc_postgresql_data:
   fregepoc_tmp:
   fregepoc_grafana_storage:
+
+  # Production
+  fregepoc_static_files:
+  fregepoc_proxy_conf:
+  fregepoc_proxy_vhost:
+  fregepoc_proxy_html:
+  fregepoc_proxy_certs:

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,14 @@
+server {
+	listen       80;
+
+	location / {
+		proxy_set_header Host $host;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+		proxy_pass http://fregepoc-backend:${DOCKER_BACKEND_PORT};
+	}
+
+    location /static/ {
+        alias /var/www/static/;
+    }
+}


### PR DESCRIPTION
This adds both a separate docker-compose environment (https://jira.frege.ii.uj.edu.pl/browse/FREGE-133) and nginx proxy with acme-companion (https://jira.frege.ii.uj.edu.pl/browse/FREGE-134). This also pins docker images to specific versions to make the deployments more reproducible.