### PR TITLE
feat: api-key auth throttling and redis cache

### DIFF
--- a/backend/fregepoc/repositories/views.py
+++ b/backend/fregepoc/repositories/views.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissions
+from rest_framework_api_key.permissions import HasAPIKey
 
 from fregepoc.repositories.models import Repository, RepositoryFile
 from fregepoc.repositories.serializers import RepositorySerializer, RepositoryFileSerializer
@@ -8,12 +9,12 @@ from fregepoc.repositories.serializers import RepositorySerializer, RepositoryFi
 class RepositoryViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Repository.objects.all()
     serializer_class = RepositorySerializer
-    permission_classes = [DjangoModelPermissions]
+    permission_classes = [DjangoModelPermissions | HasAPIKey]
     filterset_fields = ['analyzed']
 
 
 class RepositoryFileViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = RepositoryFile.objects.all()
     serializer_class = RepositoryFileSerializer
-    permission_classes = [DjangoModelPermissions]
+    permission_classes = [DjangoModelPermissions | HasAPIKey]
     filterset_fields = ['repository', 'analyzed', 'language']

--- a/backend/fregepoc/utils/throttling.py
+++ b/backend/fregepoc/utils/throttling.py
@@ -1,0 +1,18 @@
+from rest_framework.throttling import SimpleRateThrottle
+from rest_framework_api_key.permissions import KeyParser
+
+
+class ApiKeyRateThrottle(SimpleRateThrottle):
+    scope = 'apikey'
+
+    def get_cache_key(self, request, view):
+        key = KeyParser().get(request)
+        if key:
+            ident = key
+        else:
+            ident = self.get_ident(request)
+
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': ident
+        }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ django-filter~=21.1
 requests~=2.25.1
 beautifulsoup4~=4.9.3
 django-cors-headers~=3.11.0
+djangorestframework-api-key~=2.2.0
 
 # Currently unused/useful for later:
 # channels


### PR DESCRIPTION
Throttling done on per API key bases. 500 requests/minute/api key limit should be a safe default for now.
Redis cache added to support throttling.