### PR TITLE
fix: DOWNLOAD_PATH inconsistent with FHS

### DIFF
--- a/backend/fregepoc/settings.py
+++ b/backend/fregepoc/settings.py
@@ -153,4 +153,4 @@ CELERY_CACHE_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/"
 
 # MISC
 
-DOWNLOAD_PATH = os.environ.get("DJANGO_DOWNLOAD_PATH", "/usr/fregepoc-tmp/")
+DOWNLOAD_PATH = os.environ.get("DJANGO_DOWNLOAD_PATH", "/var/tmp/frege/")


### PR DESCRIPTION
The Filesystem Hierarchy Standard defines `/usr` directory as "shareable, read-only data" and specifies that "any information that is host-specific or varies with time is stored elsewhere" (see: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html).

Due to that we should not store temporary files there, but use `/var/tmp` instead.

rel: https://jira.frege.ii.uj.edu.pl/browse/FREGE-166