### PR TITLE
feat: grafana datasource+dashboard provisioning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,11 @@ services:
     container_name: fregepoc-grafana
     depends_on:
       - fregepoc-prometheus
+      - fregepoc-postgres
     volumes:
       - fregepoc_grafana_storage:/var/lib/grafana
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
     environment:
       - GF_USERS_DEFAULT_THEME=dark
       - GF_USERS_ALLOW_SIGN_UP=false

--- a/grafana/provisioning/dashboards/redis.yaml
+++ b/grafana/provisioning/dashboards/redis.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+providers:
+  - name: 'Redis dashboard'
+    orgId: 1
+    folder: 'Redis'
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: false
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /etc/grafana/provisioning/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: true 

--- a/grafana/provisioning/dashboards/redis_dashboard.json
+++ b/grafana/provisioning/dashboards/redis_dashboard.json
@@ -1,0 +1,168 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "redis-datasource",
+        "uid": "PA7F6415749A3297A"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "used_memory"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "command": "info",
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "PA7F6415749A3297A"
+          },
+          "field": "used_memory",
+          "query": "",
+          "refId": "A",
+          "section": "memory",
+          "streaming": true,
+          "type": "command"
+        }
+      ],
+      "title": "Redis: Allocated bytes",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Redis",
+  "uid": "8lpCA3unk",
+  "version": 2,
+  "weekStart": ""
+}

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+datasources:
+- name: postgres
+  type: postgres
+  access: proxy
+  url: fregepoc-postgres:5432
+  password: admin
+  user: frege
+  database: dashboard
+  basicAuth: false
+  isDefault: true
+  jsonData:
+     sslmode: disable
+  version: 1
+  editable: true
+
+

--- a/grafana/provisioning/datasources/datasource_redis.yml
+++ b/grafana/provisioning/datasources/datasource_redis.yml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+deleteDatasources:
+
+datasources:
+- name: Redis
+  type: redis-datasource
+  access: proxy
+  orgId: 1
+  isDefault: false
+  version: 1
+  url: redis://fregepoc-redis:6379
+  jsonData:
+    client: standalone
+    poolSize: 5
+    timeout: 10
+    pingInterval: 0
+    pipelineWindow: 0
+  editable: true


### PR DESCRIPTION
Added datasource: postgres and redis.
One Redis dashboard to display current memory allocation.